### PR TITLE
wrote deconvolutional brick and tests

### DIFF
--- a/tests/bricks/test_bricks.py
+++ b/tests/bricks/test_bricks.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_equal
 from cuboid.bricks import Dropout, FilterPool, Highway
 from cuboid.bricks.batch_norm import BatchNormalization
 from cuboid.bricks import LeakyRectifier, FuncBrick, DefaultsSequence
-from cuboid.bricks import Convolutional, Flattener, MaxPooling
+from cuboid.bricks import Convolutional, Flattener, MaxPooling, Deconvolutional
 
 from blocks.initialization import Constant
 from blocks.initialization import Identity as init_Identity
@@ -200,3 +200,15 @@ def test_highway_activation():
     ret = _func(x_val)
     assert_allclose(ret, np.tanh(np.ones((4,100))))
 
+def test_deconvolutional():
+    deconv = Deconvolutional([3, 4, 4], num_filters=10, filter_size=(3, 3), pad=(2, 2), stride=(2, 2))
+    deconv.biases_init = Constant(0.0)
+    deconv.weights_init = Constant(1.0)
+    deconv.initialize()
+    x = T.tensor4('input')
+    y = deconv.apply(x)
+    func_ = theano.function([x], y)
+
+    x_val = np.ones((1, 3, 4, 4), dtype=theano.config.floatX)
+    res = func_(x_val)
+    assert_allclose(res.shape, (1, 10, 8, 8))


### PR DESCRIPTION
The Deconvolutional brick is a subclass of the Convolutional brick except I changed the apply method to follow alec's deconv procedure

```
def deconv(X, w, subsample=(1, 1), border_mode=(0, 0), conv_mode='conv'):
    img = gpu_contiguous(X)
    kerns = gpu_contiguous(w)
    desc = GpuDnnConvDesc(border_mode=border_mode, subsample=subsample,
                          conv_mode=conv_mode)(gpu_alloc_empty(img.shape[0], kerns.shape[1], img.shape[2]*subsample[0], img.shape[3]*subsample[1]).shape, kerns.shape)
    out = gpu_alloc_empty(img.shape[0], kerns.shape[1], img.shape[2]*subsample[0], img.shape[3]*subsample[1])
    d_img = GpuDnnConvGradI()(kerns, img, out, desc)
    return d_img
```

One thing to note, the kernels get a little wonky since deconv maps from an output to an input. Instead of having kernels of shape (output_size, input_size, width, height), deconv's kernels are (input_size, output_size, width, height). To handle this, I do a dimshuffle on line 494. I think this should work but wanted to make a special note of it.